### PR TITLE
Allow to redefine api_url

### DIFF
--- a/lib/kong/client.rb
+++ b/lib/kong/client.rb
@@ -20,18 +20,19 @@ module Kong
     end
 
     def self.api_url
-      self.instance.api_url
+      @api_url
     end
 
     def self.api_url=(url)
-      self.instance.api_url = url
+      @api_url = url
     end
 
     # Kong Admin API URL
     #
     # @return [String]
-    def api_url      
-      @api_url ||= ENV['KONG_URI'] || 'http://localhost:8001'
+    def api_url
+      @api_url ||=
+        self.class.api_url || ENV['KONG_URI'] || 'http://localhost:8001'
     end
 
     def api_url=(url)

--- a/spec/kong/client_spec.rb
+++ b/spec/kong/client_spec.rb
@@ -24,6 +24,20 @@ describe Kong::Client do
   end
 
   describe '#api_url' do
+
+    def client_params
+      uri = URI.parse described_class.api_url
+      params = {
+        host: uri.host,
+        hostname: uri.hostname,
+        path: uri.path,
+        port: uri.port,
+        query: uri.query,
+        scheme: uri.scheme
+      }
+      described_class.instance.http_client.params.merge(params)
+    end
+
     it 'returns localhost as default' do
       described_class.api_url = nil
       expect(subject.api_url).to eq('http://localhost:8001')
@@ -43,6 +57,13 @@ describe Kong::Client do
       url = 'http://foo.bar:1337'
       described_class.api_url = url
       expect(described_class.send(:new).api_url).to eq(url)
+    end
+
+    it 'can edit api_url' do
+      described_class.api_url = nil
+      expect(described_class.instance.http_client.params).to eq(client_params)
+      described_class.api_url = 'http://foo.bar:1337'
+      expect(described_class.instance.http_client.params).to eq(client_params)
     end
   end
 

--- a/spec/kong/client_spec.rb
+++ b/spec/kong/client_spec.rb
@@ -12,6 +12,7 @@ describe Kong::Client do
 
   describe '#initialize' do
     it 'initializes Excon with Kong URI' do
+      described_class.api_url = nil
       expect(Excon).to receive(:new).with('http://localhost:8001', { omit_default_port: true })
       described_class.send(:new)
     end
@@ -24,6 +25,7 @@ describe Kong::Client do
 
   describe '#api_url' do
     it 'returns localhost as default' do
+      described_class.api_url = nil
       expect(subject.api_url).to eq('http://localhost:8001')
     end
 
@@ -32,8 +34,15 @@ describe Kong::Client do
       allow(ENV).to receive(:[]).with('no_proxy')
       allow(ENV).to receive(:[]).with('SSL_IGNORE_ERRORS')
       allow(ENV).to receive(:[]).with('KONG_URI').and_return('http://kong-api:8001')
+      described_class.api_url = nil
       subject = described_class.send(:new)
       expect(subject.api_url).to eq('http://kong-api:8001')
+    end
+
+    it 'returns custom api_url if set' do
+      url = 'http://foo.bar:1337'
+      described_class.api_url = url
+      expect(described_class.send(:new).api_url).to eq(url)
     end
   end
 


### PR DESCRIPTION
My previous PR allowed to set a custom api_url attribute and not use the default one. But it wasn't possible to override this attribute multiple times during execution. 
That's what this PR does.