### PR TITLE
Add support for Kong v 0.10.0rc3

### DIFF
--- a/lib/kong/api.rb
+++ b/lib/kong/api.rb
@@ -2,7 +2,7 @@ module Kong
   class Api
     include Base
 
-    ATTRIBUTE_NAMES = %w(id name request_host request_path strip_request_path preserve_host upstream_url).freeze
+    ATTRIBUTE_NAMES = %w(id name hosts uris strip_uri preserve_host upstream_url).freeze
     API_END_POINT = '/apis/'.freeze
 
     ##

--- a/lib/kong/api.rb
+++ b/lib/kong/api.rb
@@ -2,7 +2,7 @@ module Kong
   class Api
     include Base
 
-    ATTRIBUTE_NAMES = %w(id name hosts uris strip_uri preserve_host upstream_url).freeze
+    ATTRIBUTE_NAMES = %w(id name request_host request_path strip_request_path hosts uris strip_uri preserve_host upstream_url).freeze
     API_END_POINT = '/apis/'.freeze
 
     ##

--- a/spec/kong/api_spec.rb
+++ b/spec/kong/api_spec.rb
@@ -2,7 +2,7 @@ require_relative "../spec_helper"
 
 describe Kong::Api do
   let(:valid_attribute_names) do
-    %w(id name hosts uris strip_uri preserve_host upstream_url)
+    %w(id name request_host request_path strip_request_path hosts uris strip_uri preserve_host upstream_url)
   end
 
   describe 'ATTRIBUTE_NAMES' do

--- a/spec/kong/api_spec.rb
+++ b/spec/kong/api_spec.rb
@@ -2,7 +2,7 @@ require_relative "../spec_helper"
 
 describe Kong::Api do
   let(:valid_attribute_names) do
-    %w(id name request_host request_path strip_request_path preserve_host upstream_url)
+    %w(id name hosts uris strip_uri preserve_host upstream_url)
   end
 
   describe 'ATTRIBUTE_NAMES' do


### PR DESCRIPTION
Kong Admin API to create apis has been changed.
This PR updates the `ATTRIBUTE_NAMES` to the new attributes and removed the old ones.