### PR TITLE
Add new attributes to api model

### DIFF
--- a/lib/kong/api.rb
+++ b/lib/kong/api.rb
@@ -2,7 +2,12 @@ module Kong
   class Api
     include Base
 
-    ATTRIBUTE_NAMES = %w(id name request_host request_path strip_request_path hosts uris strip_uri preserve_host upstream_url).freeze
+    ATTRIBUTE_NAMES = %w(
+      id name request_host request_path strip_request_path
+      hosts uris strip_uri preserve_host upstream_url retries
+      upstream_connect_timeout upstream_send_timeout upstream_read_timeout
+      https_only http_if_terminated
+    ).freeze
     API_END_POINT = '/apis/'.freeze
 
     ##

--- a/spec/kong/api_spec.rb
+++ b/spec/kong/api_spec.rb
@@ -2,7 +2,12 @@ require_relative "../spec_helper"
 
 describe Kong::Api do
   let(:valid_attribute_names) do
-    %w(id name request_host request_path strip_request_path hosts uris strip_uri preserve_host upstream_url)
+    %w(
+      id name request_host request_path strip_request_path
+      hosts uris strip_uri preserve_host upstream_url retries
+      upstream_connect_timeout upstream_send_timeout upstream_read_timeout
+      https_only http_if_terminated
+    )
   end
 
   describe 'ATTRIBUTE_NAMES' do


### PR DESCRIPTION
This PR will add missing attributes to `Kong::Api` model:
- retries
- upstream_connect_timeout 
- upstream_send_timeout
- upstream_read_timeout
- https_only
- http_if_terminated