### PR TITLE
Fixing syntax highlight for ruby code on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ plugin.delete
 
 #### Upstream and Targets (for load-balanced APIs)
 
-```
+```ruby
 Kong::Upstream.list(filters)
 Kong::Upstream.all()
 Kong::Upstream.find(id)


### PR DESCRIPTION
Just a small fix for properly highlight the syntax of ruby code on README ;)