### PR TITLE
Remove Excon version number dependency

### DIFF
--- a/kong.gemspec
+++ b/kong.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_runtime_dependency "excon", "~> 0.49.0"
+  spec.add_runtime_dependency "excon"
 end

--- a/lib/kong/version.rb
+++ b/lib/kong/version.rb
@@ -1,3 +1,3 @@
 module Kong
-  VERSION = '0.3.1'.freeze
+  VERSION = '0.3.2'.freeze
 end


### PR DESCRIPTION
Excon is now at version 0.6.0, which makes newer applications unable to consume this library.