### PR TITLE
[WIP] Allow to operate against multiple Kong API servers

### DIFF
--- a/lib/kong.rb
+++ b/lib/kong.rb
@@ -1,5 +1,7 @@
 require 'kong/version'
 require_relative 'kong/base'
+require_relative 'kong/rootless'
+require_relative 'kong/collection'
 require_relative 'kong/api'
 require_relative 'kong/belongs_to_api'
 require_relative 'kong/client'

--- a/lib/kong/api.rb
+++ b/lib/kong/api.rb
@@ -13,7 +13,7 @@ module Kong
     ##
     # @return [Array<Kong::Plugin>]
     def plugins
-      Plugin.list({ api_id: self.id })
+      Plugin.list({ api_id: self.id }, client: self.client)
     end
   end
 end

--- a/lib/kong/belongs_to_api.rb
+++ b/lib/kong/belongs_to_api.rb
@@ -10,7 +10,7 @@ module Kong
     # Get Api resource
     # @return [Kong::Api]
     def api
-      @api ||= Api.find(self.api_id)
+      @api ||= Api.find(self.api_id, client: self.client)
     end
 
     # Set Api resource

--- a/lib/kong/belongs_to_consumer.rb
+++ b/lib/kong/belongs_to_consumer.rb
@@ -10,7 +10,7 @@ module Kong
     # Get Consumer resource
     # @return [Kong::Consumer]
     def consumer
-      @consumer ||= Consumer.find(self.consumer_id)
+      @consumer ||= Consumer.find(self.consumer_id, client: self.client)
     end
 
     # Set Consumer resource

--- a/lib/kong/collection.rb
+++ b/lib/kong/collection.rb
@@ -1,0 +1,31 @@
+module Kong
+  class Collection
+    def initialize(klass, client, api_end_point = nil)
+      @klass = klass
+      @client = client
+      @api_end_point = api_end_point
+    end
+
+    def first
+      self.list.first
+    end
+
+    def last
+      self.all.last
+    end
+
+    def method_missing(method, *arguments, &block)
+      opts = { client: @client, collection: self, api_end_point: @api_end_point }
+      if arguments.size == 0
+        arguments = [{}, opts]
+      else
+        arguments << opts
+      end
+      @klass.send(method, *arguments)
+    end
+
+    def respond_to?(method, include_private = false)
+      @klass.respond_to?(method, include_private)
+    end
+  end
+end

--- a/lib/kong/consumer.rb
+++ b/lib/kong/consumer.rb
@@ -16,49 +16,28 @@ module Kong
     #
     # @return [Array<Kong::Plugin>]
     def plugins
-      Plugin.list({ consumer_id: self.id })
+      Plugin.list({ consumer_id: self.id }, client: self.client)
     end
 
     # List OAuth applications
     #
     # @return [Array<Kong::OAuthApp>]
     def oauth_apps
-      apps = []
-      response = client.get("#{@api_end_point}#{self.id}/oauth2") rescue nil
-      if response
-        response['data'].each do |attributes|
-          apps << Kong::OAuthApp.new(attributes)
-        end
-      end
-      apps
+      Collection.new(OAuthApp, self.client, "#{@api_end_point}#{self.id}/oauth2").all
     end
 
     # List KeyAuth credentials
     #
     # @return [Array<Kong::KeyAuth]
     def basic_auths
-      apps = []
-      response = client.get("#{@api_end_point}#{self.id}/basic-auth") rescue nil
-      if response
-        response['data'].each do |attributes|
-          apps << Kong::BasicAuth.new(attributes)
-        end
-      end
-      apps
+      Collection.new(BasicAuth, self.client, "#{@api_end_point}#{self.id}/basic-auth").all
     end
 
     # List KeyAuth credentials
     #
     # @return [Array<Kong::KeyAuth]
     def key_auths
-      apps = []
-      response = client.get("#{@api_end_point}#{self.id}/key-auth") rescue nil
-      if response
-        response['data'].each do |attributes|
-          apps << Kong::KeyAuth.new(attributes)
-        end
-      end
-      apps
+      Collection.new(KeyAuth, self.client, "#{@api_end_point}#{self.id}/key-auth").all
     end
 
     # List OAuth2Tokens
@@ -66,7 +45,7 @@ module Kong
     # @return [Array<Kong::OAuth2Token>]
     def oauth2_tokens
       if self.custom_id
-        OAuth2Token.list({ authenticated_userid: self.custom_id })
+        OAuth2Token.list({ authenticated_userid: self.custom_id }, client: self.client)
       else
         []
       end
@@ -76,28 +55,14 @@ module Kong
     #
     # @return [Array<Kong::Acl>]
     def acls
-      acls = []
-      response = client.get("#{@api_end_point}#{self.id}/acls") rescue nil
-      if response
-        response['data'].each do |attributes|
-          acls << Kong::Acl.new(attributes)
-        end
-      end
-      acls
+      Collection.new(Acl, self.client, "#{@api_end_point}#{self.id}/acls").all
     end
 
     # List JWTs
     #
     # @return [Array<Kong::JWT>]
     def jwts
-      apps = []
-      response = client.get("#{@api_end_point}#{self.id}/jwt") rescue nil
-      if response
-        response['data'].each do |attributes|
-          apps << Kong::JWT.new(attributes)
-        end
-      end
-      apps
+      Collection.new(JWT, self.client, "#{@api_end_point}#{self.id}/jwt").all
     end
   end
 end

--- a/lib/kong/oauth2_token.rb
+++ b/lib/kong/oauth2_token.rb
@@ -8,7 +8,7 @@ module Kong
     # Get OAuthApp resource
     # @return [Kong::OAuthApp]
     def oauth_app
-      Kong::OAuthApp.find_by_id(self.credential_id)
+      Kong::OAuthApp.find_by_id(self.credential_id, client: self.client)
     end
   end
 end

--- a/lib/kong/plugin.rb
+++ b/lib/kong/plugin.rb
@@ -8,24 +8,24 @@ module Kong
 
     # Create resource
     def create
-      if attributes['config']
-        attributes['config'].each do |key, value|
-          attributes["config.#{key}"] = value
-        end
-        attributes.delete('config')
-      end
+      transform_config_attributes!
       super
     end
 
     # update resource
     def update
-      if attributes['config']
-        attributes['config'].each do |key, value|
-          attributes["config.#{key}"] = value
-        end
-        attributes.delete('config')
-      end
+      transform_config_attributes!
       super
+    end
+
+    protected
+
+    def transform_config_attributes!
+      return unless attributes['config']
+      attributes['config'].each do |key, value|
+        attributes["config.#{key}"] = value
+      end
+      attributes.delete('config')
     end
   end
 end

--- a/lib/kong/rootless.rb
+++ b/lib/kong/rootless.rb
@@ -1,0 +1,20 @@
+module Kong
+  module Rootless
+    module ClassMethods
+      def find(id, opts={})
+        raise NotImplementedError, 'Kong does not support direct access to this resource'
+      end
+
+      def list(params = {}, opts = {})
+        raise NotImplementedError, 'Kong does not support direct access to this resource'
+      end
+
+      def all(params = {}, opts = {})
+        raise NotImplementedError, 'Kong does not support direct access to this resource'
+      end
+    end
+    def self.included(base)
+      base.extend(ClassMethods)
+    end
+  end
+end

--- a/lib/kong/server.rb
+++ b/lib/kong/server.rb
@@ -5,19 +5,19 @@ module Kong
     end
 
     def self.info
-      Client.instance.get('/')
+      Client.instance.info
     end
 
     def self.status
-      Client.instance.get('/status')
+      Client.instance.status
     end
 
     def self.cluster
-      Client.instance.get('/cluster')
+      Client.instance.cluster
     end
 
     def self.remove_node(name)
-      Client.instance.delete("/cluster/nodes/#{name}")
+      Client.instance.remove_node(name)
     end
   end
 end

--- a/lib/kong/target.rb
+++ b/lib/kong/target.rb
@@ -1,20 +1,14 @@
 module Kong
   class Target
     include Base
+    include Rootless
 
     ATTRIBUTE_NAMES = %w(id upstream_id target weight).freeze
     API_END_POINT = '/targets/'.freeze
 
-    def self.find(id)
-      raise NotImplementedError, 'Kong does not support direct access to targets, you must go via an upstream'
-    end
 
-    def self.list(params = {})
-      raise NotImplementedError, 'Kong does not support direct access to targets, you must go via an upstream'
-    end
-
-    def initialize(attributes = {})
-      super(attributes)
+    def initialize(attributes = {}, opts = {})
+      super(attributes, opts)
       raise ArgumentError, 'You must specify an upstream_id' unless self.upstream_id
     end
 
@@ -41,7 +35,7 @@ module Kong
     # Get Upstream resource
     # @return [Kong::Upstream]
     def upstream
-      @upstream ||= Upstream.find(self.upstream_id)
+      @upstream ||= Upstream.find(self.upstream_id, client: self.client)
     end
 
     # Set Upstream resource

--- a/lib/kong/upstream.rb
+++ b/lib/kong/upstream.rb
@@ -9,7 +9,7 @@ module Kong
     # @return [Array<Kong::Target>]
     def targets
       targets   = []
-      json_data = Client.instance.get("#{API_END_POINT}#{self.id}/targets")
+      json_data = self.client.get("#{API_END_POINT}#{self.id}/targets")
 
       if json_data['data']
         json_data['data'].each do |target_data|

--- a/spec/kong/api_spec.rb
+++ b/spec/kong/api_spec.rb
@@ -25,7 +25,7 @@ describe Kong::Api do
   describe '.plugins' do
     it 'requests plugins attached to Api' do
       subject.id = '12345'
-      expect(Kong::Plugin).to receive(:list).with({ api_id: subject.id })
+      expect(Kong::Plugin).to receive(:list).with({ api_id: subject.id }, { client: Kong::Client.instance })
       subject.plugins
     end
   end

--- a/spec/kong/client_spec.rb
+++ b/spec/kong/client_spec.rb
@@ -10,6 +10,24 @@ describe Kong::Client do
     spy
   end
 
+  describe '.api_url=' do
+    it 'updates api_url attribute' do
+      described_class.api_url = 'http://kong-api:8001'
+      expect(described_class.api_url).to eq('http://kong-api:8001')
+    end
+
+    it 'updates client instance' do
+      described_class.api_url = 'http://kong-api:8001'
+      expect(described_class.instance.api_url).to eq('http://kong-api:8001')
+    end
+  end
+
+  describe '.instance' do
+    it 'returns shared instance' do
+      expect(described_class.instance.is_a?(described_class)).to be_truthy
+    end
+  end
+
   describe '#initialize' do
     it 'initializes Excon with Kong URI' do
       described_class.api_url = nil
@@ -67,16 +85,74 @@ describe Kong::Client do
     end
   end
 
+  describe '#consumers' do
+    it 'returns Collection object for Kong::Consumer' do
+      expect(Kong::Collection).to receive(:new).with(Kong::Consumer, subject).and_call_original
+      subject.consumers
+    end
+  end
+
+  describe '#apis' do
+    it 'returns Collection object for Kong::Api' do
+      expect(Kong::Collection).to receive(:new).with(Kong::Api, subject).and_call_original
+      subject.apis
+    end
+  end
+
+  describe '#oauth_apps' do
+    it 'returns Collection object for Kong::OAuthApp' do
+      expect(Kong::Collection).to receive(:new).with(Kong::OAuthApp, subject).and_call_original
+      subject.oauth_apps
+    end
+  end
+
+  describe '#oauth2_tokens' do
+    it 'returns Collection object for Kong::OAuth2Token' do
+      expect(Kong::Collection).to receive(:new).with(Kong::OAuth2Token, subject).and_call_original
+      subject.oauth2_tokens
+    end
+  end
+
+  describe '#plugins' do
+    it 'returns Collection object for Kong::Plugin' do
+      expect(Kong::Collection).to receive(:new).with(Kong::Plugin, subject).and_call_original
+      subject.plugins
+    end
+  end
+
+  describe '#targets' do
+    it 'returns Collection object for Kong::Target' do
+      expect(Kong::Collection).to receive(:new).with(Kong::Target, subject).and_call_original
+      subject.targets
+    end
+  end
+
+  describe '#info' do
+    it 'request root endpoint' do
+      expect(subject).to receive(:get).with('/')
+      subject.info
+    end
+  end
+
+  describe '#status' do
+    it 'request status endpoint' do
+      expect(subject).to receive(:get).with('/status')
+      subject.status
+    end
+  end
+
+  describe '#cluster' do
+    it 'request cluster endpoint' do
+      expect(subject).to receive(:get).with('/cluster')
+      subject.cluster
+    end
+  end
+
   describe '#get' do
     before(:each) do
       allow(subject).to receive(:http_client).and_return(http_client)
     end
     it 'creates HTTP GET request with given params' do
-      http_client_params = {
-        path: 'path',
-        query: { key: 'value' },
-        headers: {}
-      }
       response = spy
       allow(response).to receive(:status).and_return(200)
       expect(http_client).to receive(:get).and_return(response)
@@ -84,11 +160,6 @@ describe Kong::Client do
     end
 
     it 'raises Kong::Error if request returns error' do
-      http_client_params = {
-        path: 'path',
-        query: { key: 'value' },
-        headers: {}
-      }
       response = spy
       allow(response).to receive(:status).and_return(403)
       expect(http_client).to receive(:get).and_return(response)
@@ -98,11 +169,6 @@ describe Kong::Client do
     end
 
     it 'parses response JSON' do
-      http_client_params = {
-        path: 'path',
-        query: { key: 'value' },
-        headers: {}
-      }
       response = spy
       allow(response).to receive(:status).and_return(200)
       allow(response).to receive(:body).and_return({ id: '12345' }.to_json)
@@ -112,11 +178,6 @@ describe Kong::Client do
     end
 
     it 'returns response text' do
-      http_client_params = {
-        path: 'path',
-        query: { key: 'value' },
-        headers: {}
-      }
       response = spy
       allow(response).to receive(:status).and_return(200)
       allow(response).to receive(:body).and_return('<html></html>')
@@ -131,11 +192,6 @@ describe Kong::Client do
       allow(subject).to receive(:http_client).and_return(http_client)
     end
     it 'creates HTTP POST request with given params' do
-      http_client_params = {
-        path: 'path',
-        query: { key: 'value' },
-        headers: {}
-      }
       response = spy
       allow(response).to receive(:status).and_return(200)
       expect(http_client).to receive(:post).and_return(response)
@@ -144,11 +200,6 @@ describe Kong::Client do
 
 
     it 'raises Kong::Error if request returns error' do
-      http_client_params = {
-        path: 'path',
-        query: { key: 'value' },
-        headers: {}
-      }
       response = spy
       allow(response).to receive(:status).and_return(403)
       expect(http_client).to receive(:post).and_return(response)
@@ -158,11 +209,6 @@ describe Kong::Client do
     end
 
     it 'parses response JSON' do
-      http_client_params = {
-        path: 'path',
-        query: { key: 'value' },
-        headers: {}
-      }
       response = spy
       allow(response).to receive(:status).and_return(200)
       allow(response).to receive(:body).and_return({ id: '12345' }.to_json)
@@ -176,11 +222,6 @@ describe Kong::Client do
       allow(subject).to receive(:http_client).and_return(http_client)
     end
     it 'creates HTTP PATCH request with given params' do
-      http_client_params = {
-        path: 'path',
-        query: { key: 'value' },
-        headers: {}
-      }
       response = spy
       allow(response).to receive(:status).and_return(200)
       expect(http_client).to receive(:patch).and_return(response)
@@ -189,11 +230,6 @@ describe Kong::Client do
 
 
     it 'raises Kong::Error if request returns error' do
-      http_client_params = {
-        path: 'path',
-        query: { key: 'value' },
-        headers: {}
-      }
       response = spy
       allow(response).to receive(:status).and_return(403)
       expect(http_client).to receive(:patch).and_return(response)
@@ -203,11 +239,6 @@ describe Kong::Client do
     end
 
     it 'parses response JSON' do
-      http_client_params = {
-        path: 'path',
-        query: { key: 'value' },
-        headers: {}
-      }
       response = spy
       allow(response).to receive(:status).and_return(200)
       allow(response).to receive(:body).and_return({ id: '12345' }.to_json)
@@ -222,11 +253,6 @@ describe Kong::Client do
       allow(subject).to receive(:http_client).and_return(http_client)
     end
     it 'creates HTTP PUT request with given params' do
-      http_client_params = {
-        path: 'path',
-        query: { key: 'value' },
-        headers: {}
-      }
       response = spy
       allow(response).to receive(:status).and_return(200)
       expect(http_client).to receive(:put).and_return(response)
@@ -235,11 +261,6 @@ describe Kong::Client do
 
 
     it 'raises Kong::Error if request returns error' do
-      http_client_params = {
-        path: 'path',
-        query: { key: 'value' },
-        headers: {}
-      }
       response = spy
       allow(response).to receive(:status).and_return(403)
       expect(http_client).to receive(:put).and_return(response)
@@ -249,11 +270,6 @@ describe Kong::Client do
     end
 
     it 'parses response JSON' do
-      http_client_params = {
-        path: 'path',
-        query: { key: 'value' },
-        headers: {}
-      }
       response = spy
       allow(response).to receive(:status).and_return(200)
       allow(response).to receive(:body).and_return({ id: '12345' }.to_json)
@@ -268,11 +284,6 @@ describe Kong::Client do
       allow(subject).to receive(:http_client).and_return(http_client)
     end
     it 'creates HTTP DELETE request with given params' do
-      http_client_params = {
-        path: 'path',
-        query: {},
-        headers: {}
-      }
       response = spy
       allow(response).to receive(:status).and_return(204)
       expect(http_client).to receive(:delete).and_return(response)
@@ -281,11 +292,6 @@ describe Kong::Client do
 
 
     it 'raises Kong::Error if request returns other than 204' do
-      http_client_params = {
-        path: 'path',
-        query: {},
-        headers: {}
-      }
       response = spy
       allow(response).to receive(:status).and_return(403)
       expect(http_client).to receive(:delete).and_return(response)

--- a/spec/kong/consumer_spec.rb
+++ b/spec/kong/consumer_spec.rb
@@ -20,14 +20,14 @@ describe Kong::Consumer do
   describe '#oauth_apps' do
     it 'requests consumer\'s oauth_apps' do
       subject.id = ':id'
-      expect(Kong::Client.instance).to receive(:get).with("/consumers/:id/oauth2")
+      expect(Kong::Client.instance).to receive(:get).with("/consumers/:id/oauth2", { size: 9999999 })
         .and_return({ 'data' => [{ 'id' => '123456', 'name' => 'my app' }] })
       subject.oauth_apps
     end
 
     it 'returns list of OAuthApp' do
       subject.id = ':id'
-      allow(Kong::Client.instance).to receive(:get).with("/consumers/:id/oauth2")
+      allow(Kong::Client.instance).to receive(:get).with("/consumers/:id/oauth2",  { size: 9999999 })
         .and_return({ 'data' => [{ 'id' => '123456', 'name' => 'my app' }] })
       result = subject.oauth_apps
       expect(result.first.is_a?(Kong::OAuthApp)).to be_truthy
@@ -38,7 +38,7 @@ describe Kong::Consumer do
     context 'when custom_id is set' do
       it 'requests oauth2_tokens assigned to consumer' do
         subject.custom_id = 'custom_id'
-        expect(Kong::OAuth2Token).to receive(:list).with({ authenticated_userid: subject.custom_id })
+        expect(Kong::OAuth2Token).to receive(:list).with({ authenticated_userid: subject.custom_id }, { client: Kong::Client.instance })
         subject.oauth2_tokens
       end
     end
@@ -56,14 +56,14 @@ describe Kong::Consumer do
   describe '#acls' do
     it 'requests consumer\'s acls' do
       subject.id = ':id'
-      expect(Kong::Client.instance).to receive(:get).with("/consumers/:id/acls")
+      expect(Kong::Client.instance).to receive(:get).with("/consumers/:id/acls",  { size: 9999999 })
         .and_return({ 'data' => [{ 'id' => '123456', 'group' => 'group1' }] })
       subject.acls
     end
 
     it 'returns list of Acls' do
       subject.id = ':id'
-      allow(Kong::Client.instance).to receive(:get).with("/consumers/:id/acls")
+      allow(Kong::Client.instance).to receive(:get).with("/consumers/:id/acls",  { size: 9999999 })
         .and_return({ 'data' => [{ 'id' => '123456', 'group' => 'group1' }] })
       result = subject.acls
       expect(result.first.is_a?(Kong::Acl)).to be_truthy

--- a/spec/kong/target_spec.rb
+++ b/spec/kong/target_spec.rb
@@ -36,7 +36,7 @@ describe Kong::Target do
 
   describe '.upstream' do
     it 'requests the attached Upstream' do
-      expect(Kong::Upstream).to receive(:find).with(upstream_id)
+      expect(Kong::Upstream).to receive(:find).with(upstream_id, { client: Kong::Client.instance })
       subject.upstream
     end
   end


### PR DESCRIPTION
This PR will allow user to use `Kong::Client` objects and operate against multiple Kong API servers. 
Examples:
```
client = Kong::Client.new(url)
client.consumers.all
client.apis.create({name: 'v1'})

client2 = Kong::Client.new(url)
client2.consumers.all
```

The implementation is backward compatible.