### PR TITLE
Switch to application json content type

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in kontena-cli.gemspec
+# Specify your gem's dependencies in kong.gemspec
 gemspec
 group :development, :test do
   gem "rspec"
-  gem "rubocop"
+  gem "rubocop", "0.47"
 end

--- a/lib/kong/base.rb
+++ b/lib/kong/base.rb
@@ -111,8 +111,8 @@ module Kong
 
     # Create resource
     def create
-      headers = { 'Content-Type' => 'application/x-www-form-urlencoded' }
-      response = client.post(@api_end_point, nil, attributes, headers)
+      headers = { 'Content-Type' => 'application/json' }
+      response = client.post(@api_end_point, attributes, nil, headers)
       init_attributes(response)
       self
     end
@@ -121,15 +121,15 @@ module Kong
     # Data is sent to Kong in JSON format and HTTP PUT request is used
     def create_or_update
       headers = { 'Content-Type' => 'application/json' }
-      response = client.put("#{@api_end_point}", attributes, nil, headers)
+      response = client.put(@api_end_point, attributes, nil, headers)
       init_attributes(response)
       self
     end
 
     # Update resource
     def update
-      headers = { 'Content-Type' => 'application/x-www-form-urlencoded' }
-      response = client.patch("#{@api_end_point}#{self.id}", nil, attributes, headers)
+      headers = { 'Content-Type' => 'application/json' }
+      response = client.patch("#{@api_end_point}#{self.id}", attributes, nil, headers)
       init_attributes(response)
       self
     end

--- a/spec/kong/base_spec.rb
+++ b/spec/kong/base_spec.rb
@@ -94,18 +94,18 @@ describe Kong::Base do
 
   describe '#create' do
     it 'creates POST /:resource_end_point/ request with resource attributes' do
-      headers = { 'Content-Type' => 'application/x-www-form-urlencoded' }
+      headers = { 'Content-Type' => 'application/json' }
       attributes = { 'name' => 'test object' }
-      expect(Kong::Client.instance).to receive(:post).with('/resources/', nil, attributes, headers)
+      expect(Kong::Client.instance).to receive(:post).with('/resources/', attributes, nil, headers)
         .and_return(attributes)
       subject.name = 'test object'
       subject.create
     end
 
     it 'returns resource instance' do
-      headers = { 'Content-Type' => 'application/x-www-form-urlencoded' }
+      headers = { 'Content-Type' => 'application/json' }
       attributes = { 'name' => 'test object' }
-      allow(Kong::Client.instance).to receive(:post).with('/resources/', nil, attributes, headers)
+      allow(Kong::Client.instance).to receive(:post).with('/resources/', attributes, nil, headers)
         .and_return(attributes.merge({ 'id' => '12345' }))
       subject.name = 'test object'
       expect(subject.create).to eq(subject)
@@ -134,19 +134,19 @@ describe Kong::Base do
 
     describe '#update' do
       it 'creates PATCH /:resource_end_point/:resource_id request with resource attributes' do
-        headers = { 'Content-Type' => 'application/x-www-form-urlencoded' }
+        headers = { 'Content-Type' => 'application/json' }
         subject.id = '12345'
         subject.name = 'test object'
-        expect(Kong::Client.instance).to receive(:patch).with('/resources/12345', nil, subject.attributes, headers)
+        expect(Kong::Client.instance).to receive(:patch).with('/resources/12345', subject.attributes, nil, headers)
           .and_return(subject.attributes)
         subject.update
       end
 
       it 'returns resource instance' do
-        headers = { 'Content-Type' => 'application/x-www-form-urlencoded' }
+        headers = { 'Content-Type' => 'application/json' }
         subject.id = '12345'
         subject.name = 'test object'
-        allow(Kong::Client.instance).to receive(:patch).with('/resources/12345', nil, subject.attributes, headers)
+        allow(Kong::Client.instance).to receive(:patch).with('/resources/12345', subject.attributes, nil, headers)
           .and_return(subject.attributes)
         expect(subject.update).to eq(subject)
       end

--- a/spec/kong/plugin_spec.rb
+++ b/spec/kong/plugin_spec.rb
@@ -26,9 +26,9 @@ describe Kong::Plugin do
 
   describe '#create' do
     it 'transforms config keys to config.key format' do
-      headers = { 'Content-Type' => 'application/x-www-form-urlencoded' }
+      headers = { 'Content-Type' => 'application/json' }
       attributes = { 'api_id' => ':api_id', 'config.anonymous' => '12345' }
-      expect(Kong::Client.instance).to receive(:post).with('/apis/:api_id/plugins/', nil, attributes, headers).and_return(attributes)
+      expect(Kong::Client.instance).to receive(:post).with('/apis/:api_id/plugins/', attributes, nil, headers).and_return(attributes)
       subject = described_class.new({ api_id: ':api_id', config: { 'anonymous' => '12345' } })
       subject.create
     end
@@ -36,9 +36,9 @@ describe Kong::Plugin do
 
   describe '#update' do
     it 'transforms config keys to config.key format' do
-      headers = { 'Content-Type' => 'application/x-www-form-urlencoded' }
+      headers = { 'Content-Type' => 'application/json' }
       attributes = { 'api_id' => ':api_id', 'config.anonymous' => '12345' }
-      expect(Kong::Client.instance).to receive(:patch).with('/apis/:api_id/plugins/', nil, attributes, headers).and_return(attributes)
+      expect(Kong::Client.instance).to receive(:patch).with('/apis/:api_id/plugins/', attributes, nil, headers).and_return(attributes)
       subject = described_class.new({ api_id: ':api_id', config: { 'anonymous' => '12345' } })
       subject.update
     end


### PR DESCRIPTION
I had trouble running consumer.create against a Kong v0.14 instance. Server returned

```
# --- Caused by: ---
     # Kong::Error:
     #   {"fields":{"@entity":["at least one of these fields must be non-empty:
'custom_id', 'username'"]},"name":"schema violation","code":2,
"message":"schema violation (at least one of these fields must be
non-empty: 'custom_id', 'username')"}
     #   /ruby/path/.rvm/gems/ruby-2.5.1/gems/kong-0.3.2/lib/kong/client.rb:232:in 
`handle_error_response'
```

Of course one field (`username`) was filled but filling both made no difference. Used to work in Kong v0.11.

Some testing revealed switching the content-type for POST requests works. Tested against Kong v0.11 and v.0.14.

I can't quite explain which change in the Kong server logic caused this. Logic is likely in https://github.com/Kong/kong/commits/master/kong/api/arguments.lua Their upgrade/migration/changelog notes and issue tracker doesn't list anything relevant.
