### PR TITLE
Expose error status

### DIFF
--- a/lib/kong/error.rb
+++ b/lib/kong/error.rb
@@ -1,5 +1,7 @@
 module Kong
   class Error < StandardError
+    attr_reader :status
+
     def initialize(status, message)
       @status = status
       super(message)

--- a/spec/kong/error_spec.rb
+++ b/spec/kong/error_spec.rb
@@ -1,0 +1,23 @@
+require_relative "../spec_helper"
+
+describe Kong::Error do
+  let(:instance) { described_class.new(status, message) }
+  let(:status) { 123 }
+  let(:message) { 'Error Message' }
+
+  describe '.status' do
+    subject { instance.status }
+
+    it 'exposes error status' do
+      is_expected.to eq status
+    end
+  end
+
+  describe '.message' do
+    subject { instance.message }
+
+    it 'exposes error message' do
+      is_expected.to eq message
+    end
+  end
+end


### PR DESCRIPTION
Adds an accessor on `Kong::Error` for accessing the error status.

It may be useful for implementing error recovery logics.