### PR TITLE
Travis-CI: Ruby 2.3 is EOL (not maintained), add Ruby 2.4,2.5,2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: ruby
 rvm:
-  - 2.0.0-p648
-  - 2.1.9
-  - 2.2.5
-  - 2.3.1
+  - 2.4
+  - 2.5
+  - 2.6
 cache: bundler
 script: bundle install && bundle exec rspec spec/


### PR DESCRIPTION
Test against current releases of Ruby https://endoflife.software/programming-languages/server-side-scripting/ruby